### PR TITLE
Fix parallelism

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM pytorch/pytorch:1.12.1-cuda11.3-cudnn8-runtime
 WORKDIR /app
-COPY *.py requirements.txt /app
+COPY *.py requirements.txt *.pickle /app
 RUN apt update && apt install -y git
 RUN pip install -r requirements.txt
 ENV GRADIO_SERVER_PORT=7860


### PR DESCRIPTION
When parallelism is enabled, there is this error:

```sh
No such file or directory: './clip_config.pickle
```

As referenced in #34. This PR fixes that by adding the pickle file to the COPY command in the Dockerfile.